### PR TITLE
Tweak test setup

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,18 +3,24 @@
 import nox
 
 
-@nox.session(name="test")
+@nox.session(name="test", venv_backend="mamba")
 def run_test(session):
     """Run pytest on all test cases."""
+    session.conda_install("pip", channel="conda-forge")
+    session.conda_install("highs", channel="conda-forge")
+    session.conda_install("gurobi", channel="gurobi")
     session.install(".")
     session.install("pytest")
     session.install("pytest-timeout")
     session.run("pytest", *session.posargs)
 
 
-@nox.session(name="fast-test")
+@nox.session(name="fast-test", venv_backend="mamba")
 def run_test_fast(session):
     """Run pytest on fast test cases."""
+    session.conda_install("pip", channel="conda-forge")
+    session.conda_install("highs", channel="conda-forge")
+    session.conda_install("gurobi", channel="gurobi")
     session.install(".")
     session.install("pytest")
     session.install("pytest-timeout")

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,28 +3,39 @@
 import nox
 
 
-@nox.session(name="test", venv_backend="mamba")
-def run_test(session):
-    """Run pytest on all test cases."""
+def _setup_test_session(session):
+    # install pip via conda to handle pip deps
     session.conda_install("pip", channel="conda-forge")
+    # install core solvers
     session.conda_install("highs", channel="conda-forge")
     session.conda_install("gurobi", channel="gurobi")
+    # install project
+    session.conda_install("numpy", channel="conda-forge")
+    session.conda_install("dacite", channel="conda-forge")
     session.install(".")
     session.install("pytest")
     session.install("pytest-timeout")
-    session.run("pytest", *session.posargs)
+    return session
+
+
+@nox.session(name="test", venv_backend="mamba")
+def run_test(session):
+    """Run pytest on all test cases."""
+    session = _setup_test_session(session)
+    session.run("pytest", "-m", "not extensive", *session.posargs)
 
 
 @nox.session(name="fast-test", venv_backend="mamba")
 def run_test_fast(session):
     """Run pytest on fast test cases."""
-    session.conda_install("pip", channel="conda-forge")
-    session.conda_install("highs", channel="conda-forge")
-    session.conda_install("gurobi", channel="gurobi")
-    session.install(".")
-    session.install("pytest")
-    session.install("pytest-timeout")
-    session.run("pytest", "-m", "not slow", *session.posargs)
+    session = _setup_test_session(session)
+    session.run("pytest", "-m", "not slow and not extensive", *session.posargs)
+
+@nox.session(name="extensive-test", venv_backend="mamba")
+def run_test_fast(session):
+    """Run pytest on fast test cases."""
+    session = _setup_test_session(session)
+    session.run("pytest", *session.posargs)
 
 
 @nox.session(name="lint")

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ def _setup_test_session(session):
 
 @nox.session(name="test", venv_backend="mamba")
 def run_test(session):
-    """Run pytest on all test cases."""
+    """Run pytest on all test cases besides the extensive suite."""
     session = _setup_test_session(session)
     session.run("pytest", "-m", "not extensive", *session.posargs)
 
@@ -32,8 +32,8 @@ def run_test_fast(session):
     session.run("pytest", "-m", "not slow and not extensive", *session.posargs)
 
 @nox.session(name="extensive-test", venv_backend="mamba")
-def run_test_fast(session):
-    """Run pytest on fast test cases."""
+def run_test_extensive(session):
+    """Run pytest on all test cases."""
     session = _setup_test_session(session)
     session.run("pytest", *session.posargs)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 timeout = 120
 markers =
     slow: this test is slow and should only run locally.
+    extensive: this test is part of the extensive test suite and should also only run locally.
 filterwarnings =
     ignore::DeprecationWarning

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -72,7 +72,7 @@ scheduled_aks_params = [
             else pytest.param(param_pair, marks=[pytest.mark.slow, pytest.mark.extensive])
         )
     )
-    for param_pair in product(mus, solvers)
+    for param_pair in product(mus, available_solvers)
 ]
 
 

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -56,14 +56,23 @@ def scheduling_input(request) -> SchedulingInput:
     return SchedulingInput.from_dict(input_dict)
 
 
-fast_scheduled_ak_params = [(2, "HiGHS_CMD"), (2, "GUROBI")]
+mus = [2, 1, 5]
+available_solvers = pulp.listSolvers(onlyAvailable=True) + [None]
+core_solver_set = {"HiGHS_CMD", "GUROBI"}
+
+fast_scheduled_ak_params = list(product(mus[:1], core_solver_set))
+
 scheduled_aks_params = [
     (
         pytest.param(param_pair)
         if param_pair in fast_scheduled_ak_params
-        else pytest.param(param_pair, marks=pytest.mark.slow)
+        else (
+            pytest.param(param_pair, marks=pytest.mark.slow)
+            if param_pair[1] in core_solver_set
+            else pytest.param(param_pair, marks=[pytest.mark.slow, pytest.mark.extensive])
+        )
     )
-    for param_pair in product([2, 1, 5], pulp.listSolvers(onlyAvailable=True) + [None])
+    for param_pair in product(mus, solvers)
 ]
 
 


### PR DESCRIPTION
This PR does the following:
* add the test mark `extensive` to mark tests on solvers besides `HiGHS` and `GUROBI`.
* The session `test` does only run all slow and fast tests for solvers `HiGHS` and `GUROBI`.
* Added new session `extensive-test` to run all test cases, including other solvers.
* Moved test session setup to mamba / conda to install solvers.