### PR TITLE
Improve solver result handling

### DIFF
--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -11,10 +11,10 @@ from pulp import (
     LpBinary,
     LpMaximize,
     LpProblem,
-    LpStatus,
-    LpStatusInfeasible,
     LpSolutionInfeasible,
     LpSolutionNoSolutionFound,
+    LpStatus,
+    LpStatusInfeasible,
     LpVariable,
     getSolver,
     lpSum,
@@ -407,7 +407,8 @@ def export_scheduling_result(
 
     def _get_val(var: LpVariable) -> int:
         ret_val = (
-            # We know there is distinction works as intended for gurobi, PuLP and HiGHS. There might be other solvers (supported by pulp) that need special handling.
+            # We know there is distinction works as intended for gurobi, PuLP and HiGHS.
+            # There might be other solvers (supported by pulp) that need special handling.
             var.solverVar.X
             if solved_lp_problem.solver and solved_lp_problem.solver.name == "GUROBI"
             else value(var)
@@ -420,7 +421,9 @@ def export_scheduling_result(
 
     scheduled_ak_dict: dict[str, dict[str, list[str] | str]] = defaultdict(dict)
 
-    # Handle rooms differntly because we want special handling if AKs are scheduled into more than one room. 
+    # Handle rooms differntly because we want special handling if
+    # AKs are scheduled into more than one room.
+    # Also the field `ak_id` is set initially.
     for ak_id, set_room_ids in var_value_dict["Room"].items():
         sum_matched_rooms = sum(set_room_ids.values())
         if sum_matched_rooms == 1:
@@ -530,7 +533,7 @@ def process_solved_lp(
     """
     if solved_lp_problem.sol_status in [
         LpSolutionInfeasible,
-        LpSolutionNoSolutionFound
+        LpSolutionNoSolutionFound,
     ]:
         return None
     output_dict = export_scheduling_result(

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -431,29 +431,20 @@ def export_scheduling_result(
         else:
             raise ValueError(f"AK {ak_id} is assigned multiple rooms")
 
-    for ak_id, set_timeslot_ids in var_value_dict["Time"].items():
-        matched_timeslots = sorted(
-            [timeslot_idx for timeslot_idx, val in set_timeslot_ids.items() if val > 0]
-        )
+    def _assign_matched_ids(var_key: str, scheduled_ak_key: str, name: str):
+        for ak_id, set_ids in var_value_dict[var_key].items():
+            matched_ids = [idx for idx, val in set_ids.items() if val > 0]
+            if matched_ids:
+                scheduled_ak_dict[ak_id][scheduled_ak_key] = matched_ids
+            elif not allow_unscheduled_aks:
+                raise ValueError(f"AK {ak_id} has no assigned {name}")
 
-        if matched_timeslots:
-            scheduled_ak_dict[ak_id]["timeslot_ids"] = matched_timeslots
-        elif not allow_unscheduled_aks:
-            raise ValueError(f"AK {ak_id} has no assigned timeslots")
-
-    for ak_id, set_participant_ids in var_value_dict["Part"].items():
-        matched_participants = sorted(
-            [
-                participant_idx
-                for participant_idx, val in set_participant_ids.items()
-                if val > 0
-            ]
-        )
-
-        if matched_participants:
-            scheduled_ak_dict[ak_id]["participant_ids"] = matched_participants
-        elif not allow_unscheduled_aks:
-            raise ValueError(f"AK {ak_id} has no assigned participants")
+    _assign_matched_ids(
+        var_key="Time", scheduled_ak_key="timeslot_ids", name="timeslots"
+    )
+    _assign_matched_ids(
+        var_key="Part", scheduled_ak_key="participant_ids", name="participants"
+    )
 
     return {"scheduled_aks": list(scheduled_ak_dict.values())}
 

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -596,6 +596,11 @@ def main() -> None:
         "the prefix 'out-' is added to the input file name and it is stored in the "
         "current working directory.",
     )
+    parser.add_argument(
+        "--override-output",
+        action="store_true",
+        help="If set, overrides the output file if it exists.",
+    )
     args = parser.parse_args()
 
     solver_kwargs = {}
@@ -622,7 +627,7 @@ def main() -> None:
     if args.output is None:
         args.output = Path.cwd() / f"out-{json_file.name}"
 
-    if args.output.exists():
+    if args.output.exists() and not args.override_output:
         raise ValueError(
             f"Output file {args.output} already exists. We do not simply override it."
         )

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -11,6 +11,7 @@ from pulp import (
     LpBinary,
     LpMaximize,
     LpProblem,
+    LpSolution,
     LpSolutionInfeasible,
     LpSolutionNoSolutionFound,
     LpStatus,
@@ -501,6 +502,7 @@ def solve_scheduling(
     lp_problem.solve(solver)
 
     print("Status:", LpStatus[lp_problem.status])
+    print("Solution Status:", LpSolution[lp_problem.sol_status])
     if lp_problem.status == LpStatusInfeasible and output_lp_file is not None:
         if lp_problem.solver and lp_problem.solver.name == "GUROBI":
             # compute irreducible inconsistent subsystem for debugging, cf.

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -407,6 +407,7 @@ def export_scheduling_result(
 
     def _get_val(var: LpVariable) -> int:
         ret_val = (
+            # We know there is distinction works as intended for gurobi, PuLP and HiGHS. There might be other solvers (supported by pulp) that need special handling.
             var.solverVar.X
             if solved_lp_problem.solver and solved_lp_problem.solver.name == "GUROBI"
             else value(var)
@@ -419,6 +420,7 @@ def export_scheduling_result(
 
     scheduled_ak_dict: dict[str, dict[str, list[str] | str]] = defaultdict(dict)
 
+    # Handle rooms differntly because we want special handling if AKs are scheduled into more than one room. 
     for ak_id, set_room_ids in var_value_dict["Room"].items():
         sum_matched_rooms = sum(set_room_ids.values())
         if sum_matched_rooms == 1:

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -13,6 +13,8 @@ from pulp import (
     LpProblem,
     LpStatus,
     LpStatusInfeasible,
+    LpSolutionInfeasible,
+    LpSolutionNoSolutionFound,
     LpVariable,
     getSolver,
     lpSum,
@@ -524,7 +526,10 @@ def process_solved_lp(
         A dictionary containing the scheduled aks as well as the scheduling
         input.
     """
-    if solved_lp_problem.status == LpStatusInfeasible:
+    if solved_lp_problem.sol_status in [
+        LpSolutionInfeasible,
+        LpSolutionNoSolutionFound
+    ]:
         return None
     output_dict = export_scheduling_result(
         solved_lp_problem, allow_unscheduled_aks=allow_unscheduled_aks

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -75,7 +75,7 @@ scheduled_aks_params = [
     ],
     params=scheduled_aks_params,
 )
-def solvedLP(request, scheduling_input) -> pulp.LpProblem:
+def solved_lp_fixture(request, scheduling_input) -> pulp.LpProblem:
     """Solve an ILP."""
     mu, solver_name = request.param
     solver_kwargs = {}
@@ -96,9 +96,9 @@ def solvedLP(request, scheduling_input) -> pulp.LpProblem:
 
 
 @pytest.fixture(scope="module")
-def scheduled_aks(solvedLP) -> dict[str, dict]:
+def scheduled_aks(solved_lp_fixture) -> dict[str, dict]:
     """Construct a schedule from solved ILP."""
-    solved_lp_problem, scheduling_input = solvedLP
+    solved_lp_problem, scheduling_input = solved_lp_fixture
 
     aks = process_solved_lp(solved_lp_problem, input_data=scheduling_input)
 

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -103,7 +103,7 @@ def scheduled_aks(solved_lp_fixture) -> dict[str, dict]:
     aks = process_solved_lp(solved_lp_problem, input_data=scheduling_input)
 
     if aks is None:
-        pytest.fail("No LP solution found")
+        pytest.skip("No LP solution found")
 
     return {ak["ak_id"]: ak for ak in aks["scheduled_aks"]}
 


### PR DESCRIPTION
This PR does the following:
* Splits the logic for solving the LP and extracting a schedule dict into separate methods
* Rewrites the logic to extract a schedule dict to only rely on the LP Problem object, i.e. it no longer depends on a separate decision variable dict or the Solver input. This improves reusability, e.g. for testing.
* Handles the case where the solver simply found no solution in the allotted time the same as infeasibility (where the solver determined that no solution exists).
* Added CLI flags to determine the output JSON location and whether a potentially existing file should be overridden.
