### PR TITLE
Major rewrite: Replace PuLP with linopy and more

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,5 @@ application-import-names =
     tests
 extend-select = B950
 extend-ignore = E203,E501,E701
+exclude =
+    version.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+src/akplan/version.py
+
 __pycache__/
 *.log
 *.aux

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The interaction with a graphical frontend is done via import/export of `json` fi
 
 The general workflow is:
 1. Read in the constraints from a `.json` file. The input format is specified on [this wiki page](https://github.com/Die-KoMa/ak-plan-optimierung/wiki/Input-&-output-format#input--output-format).
-2. Construct an integer linear program (ILP) from the constraints using [PuLP](https://coin-or.github.io/pulp/). The ILP formulation is described on [this wiki page](https://github.com/Die-KoMa/ak-plan-optimierung/wiki/New-LP-Formulation).
-3. Solve the ILP using a solver supported by PuLP, e.g. HiGHS or Gurobi.
+2. Construct an integer linear program (ILP) from the constraints using [linopy](https://github.com/PyPSA/linopy). The ILP formulation is described on [this wiki page](https://github.com/Die-KoMa/ak-plan-optimierung/wiki/New-LP-Formulation).
+3. Solve the ILP using a solver supported by linopy, e.g. HiGHS or Gurobi.
 4. Output the solution into a `.json` file. The output format is specified on [this wiki page](https://github.com/Die-KoMa/ak-plan-optimierung/wiki/Input-&-output-format#input--output-format).
 
 
@@ -19,9 +19,9 @@ $ pip install git+https://github.com/Die-KoMa/ak-plan-optimierung.git
 ```
 To run the solver, simply call
 ```sh
-$ python -m akplan.solve PATH_TO_JSON_INPUT
+$ akplan-solve PATH_TO_JSON_INPUT
 ```
-For a list of available cli options, run `python -m akplan.solve --help`.
+For a list of available cli options, run `akplan-solve --help`.
 
 ### Development setup
 
@@ -30,8 +30,9 @@ Further, install the tool [`nox`](https://nox.thea.codes/en/stable/).
 
 To see all available `nox` sessions, run `nox --list`:
 ```
-* test -> Run pytest on all test cases.
+* test -> Run pytest on all test cases besides the extensive suite.
 * fast-test -> Run pytest on fast test cases.
+* extensive-test -> Run pytest on all test cases.
 * lint -> Check code conventions.
 * typing -> Check type hints.
 * format -> Fix common convention problems automatically.

--- a/noxfile.py
+++ b/noxfile.py
@@ -60,6 +60,8 @@ def lint(session):
 def mypy(session):
     """Check type hints."""
     session.install(".")
+    # TODO add dev dependencies to setup.cfg
+    session.install("pytest")
     session.install("mypy")
     session.run(
         "mypy",
@@ -68,6 +70,7 @@ def mypy(session):
         "--ignore-missing-imports",
         "--strict",
         "src",
+        "tests",
         *session.posargs
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools >= 77.0.3"]
+requires = ["setuptools >= 77.0.3", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "akplan"
 description = "Optimal conference schedules with ILPs"
-version = "0.0.2-dev"
+dynamic = ["version"]
 readme = "README.md"
 requires-python = ">= 3.11"
 license = "MIT"
@@ -13,9 +13,12 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "Progranmming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Office/Business :: Scheduling",
     "Topic :: Scientific/Engineering :: Mathematics",
+    "Typing :: Typed",
 ]
 dependencies = [
     "dacite",
@@ -45,6 +48,13 @@ typing = ["pytest", "mypy"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+akplan = ["py.typed"]
+
+[tool.setuptools_scm]
+version_file = "src/akplan/version.py"
+version_scheme = "python-simplified-semver"
 
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools >= 77.0.3"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "akplan"
+description = "Optimal conference schedules with ILPs"
+version = "0.0.2-dev"
+readme = "README.md"
+requires-python = ">= 3.11"
+license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Progranmming Language :: Python :: 3",
+    "Topic :: Office/Business :: Scheduling",
+    "Topic :: Scientific/Engineering :: Mathematics",
+]
+dependencies = [
+    "dacite",
+    "tqdm",
+    "numpy",
+    "linopy",
+    "typing_extensions",
+]
+
+[project.optional-dependencies]
+format = ["black", "isort"]
+lint = [
+    "flake8",
+    "flake8-colors",
+    "flake8-black",
+    "flake8-docstrings",
+    "flake8-bugbear",
+    "flake8-broken-line",
+    "pep8-naming",
+    "pydocstyle",
+    "darglint",
+]
+test = ["highspy", "gurobipy", "pytest", "pytest-timeout"]
+coverage = ["coverage"]
+typing = ["pytest", "mypy"]
+
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+
+[project.urls]
+Source = "https://github.com/Die-KoMa/ak-plan-optimierung"
+Download = "https://github.com/Die-KoMa/ak-plan-optimierung/releases"
+Issues = "https://github.com/Die-KoMa/ak-plan-optimierung/issues"
+
+[project.scripts]
+akplan-solve = "akplan.solve:main"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 120
+timeout = 180
 markers =
     slow: this test is slow and should only run locally.
     extensive: this test is part of the extensive test suite and should also only run locally.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     tqdm
     numpy
     linopy
+    typing_extensions
 
 packages = find:
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     dacite
     tqdm
     numpy
-    pulp @ git+https://github.com/coin-or/pulp
+    linopy
 
 packages = find:
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,37 +1,4 @@
 ##########################
-# Setup.py Configuration #
-##########################
-[metadata]
-name = akplan
-version = 0.0.1-dev
-description = Optimal conference schedules with ILPs
-long_description = file: README.md
-long_description_content_type = text/markdown
-
-# URLs associated with the project
-url = https://github.com/Die-KoMa/ak-plan-optimierung
-download_url = https://github.com/Die-KoMa/ak-plan-optimierung/releases
-project_urls =
-    Bug Tracker = https://github.com/Die-KoMa/ak-plan-optimierung/issues
-    Source Code = https://github.com/Die-KoMa/ak-plan-optimierung
-
-[options]
-install_requires =
-    dacite
-    tqdm
-    numpy
-    linopy
-    typing_extensions
-
-packages = find:
-package_dir =
-    = src
-
-[options.packages.find]
-where = src
-
-
-##########################
 # Darglint Configuration #
 ##########################
 [darglint]

--- a/src/akplan/generate_input.py
+++ b/src/akplan/generate_input.py
@@ -207,7 +207,8 @@ def generate(
     }
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run `generate` from CLI."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--persons", type=int, default=30)
     parser.add_argument("--aks", type=int, default=10)
@@ -247,3 +248,7 @@ if __name__ == "__main__":
         json.dump(output_dict, output_file, indent=4)
 
     print(f"Generated {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -183,10 +183,7 @@ def create_lp(
     m.add_constraints((block.sum("block") <= 1), name="AKSingleBlock")
     logger.debug("Constraints AKSingleBlock added")
 
-    m.add_constraints(
-        (time - props.ak_durations * block).where(props.block_mask) <= 0,
-        name="AKBlockAssign",
-    )
+    m.add_constraints((time - block).where(props.block_mask) <= 0, name="AKBlockAssign")
     logger.debug("Constraints AKBlockAssign added")
 
     m.add_constraints(

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -500,8 +500,8 @@ def main() -> None:
         default=None,
         help=(
             "The solver to use. We currently only support passing CLI args to solvers in "
-            f"{get_args(types.SupportedSolver)}. If None, uses linopy's default solver. "
-            "Defaults to None."
+            f"{get_args(types.SupportedSolver)}. If None, chooses a default "
+            "from installed solvers. Defaults to None."
         ),
     )
     parser.add_argument(
@@ -551,14 +551,14 @@ def main() -> None:
         "--threads",
         type=int,
         default=None,
-        help="Number of threads to use. Defaults to #CPUs minus 1",
+        help="Number of threads to use. Defaults to #CPUs minus 1.",
     )
     parser.add_argument(
         "--loglevel",
         type=str.lower,
         choices=["error", "warning", "info", "debug"],
         default="info",
-        help="Select logging level",
+        help="Select logging level. Defaults to 'info'.",
     )
     parser.add_argument(
         "path", type=str, help="Path of the JSON input file to the solver."

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -5,6 +5,7 @@ import json
 from dataclasses import asdict
 from itertools import combinations, product
 from pathlib import Path
+from time import perf_counter
 from typing import Any, Literal, cast, overload
 
 from pulp import (
@@ -65,6 +66,8 @@ def create_lp(
     """
     ids = ProblemIds.init_from_problem(input_data)
     props = ProblemProperties.init_from_problem(input_data, ids=ids)
+
+    time_lp_construction_start = perf_counter()
 
     # Create decision variables
     var = LPVarDicts.init_from_ids(
@@ -366,6 +369,12 @@ def create_lp(
             var.time[scheduled_ak.ak_id][timeslot_id].setInitialValue(1)
             var.time[scheduled_ak.ak_id][timeslot_id].fixValue()
 
+    time_lp_construction_end = perf_counter()
+    print(
+        "LP constructed. Time elapsed: "
+        f"{time_lp_construction_end - time_lp_construction_start:.1f}s"
+    )
+
     # The problem data is written to an .lp file
     if output_file is not None:
         prob.writeLP(output_file)
@@ -507,6 +516,7 @@ def solve_scheduling(
             iis_path = Path(output_lp_file)
             iis_path = iis_path.parent / f"{iis_path.stem}-iis.ilp"
             lp_problem.solverModel.write(str(iis_path))
+            print("IIS written")
 
     def value_processing(value: float | None) -> int | None:
         if value is None:

--- a/src/akplan/solve.py
+++ b/src/akplan/solve.py
@@ -231,7 +231,7 @@ def create_lp(
     )
     logger.debug("Constraints TimeImpossibleForRoom added")
 
-    for ak_a, ak_b in ids.conflict_pairs:
+    for ak_a, ak_b in props.conflict_pairs:
         m.add_constraints(
             time.loc[ak_a] + time.loc[ak_b] <= 1,
             name=_construct_constraint_name("AKConflict", ak_a, ak_b),
@@ -280,18 +280,18 @@ def create_lp(
 
     # TODO vectorize
     # AK dependencies
-    for ak in input_data.aks:
-        other_ak_ids = ak.properties.get("dependencies", [])
-        if not other_ak_ids:
+    for ak_id in ids.ak:
+        if ak_id not in props.dependencies:
             continue
+        other_ak_ids = props.dependencies[ak_id]
         for idx, timeslot_id in enumerate(ids.timeslot):
             m.add_constraints(
-                lhs=time.loc[ak.id, ids.timeslot[idx:]].sum("timeslot")
+                lhs=time.loc[ak_id, ids.timeslot[idx:]].sum("timeslot")
                 - time.loc[other_ak_ids, timeslot_id],
                 sign=">=",
                 rhs=0,
                 name=_construct_constraint_name(
-                    "AKDependenciesDoneBeforeAK", ak.id, timeslot_id
+                    "AKDependenciesDoneBeforeAK", ak_id, timeslot_id
                 ),
             )
     logger.debug("Constraints AKDependenciesDoneBeforeAK added")

--- a/src/akplan/types.py
+++ b/src/akplan/types.py
@@ -1,8 +1,11 @@
 """Type definitions."""
 
-from typing import Generic, NamedTuple, TypeAlias, TypeVar
+from pathlib import Path
+from typing import NamedTuple, TypedDict, TypeVar
 
-from pulp import LpVariable
+import pandas as pd
+import xarray as xr
+from typing_extensions import NotRequired
 
 Id = int
 T = TypeVar("T")
@@ -14,27 +17,23 @@ PersonId = Id
 AkId = Id
 TimeslotId = Id
 BlockId = Id
-Block = list[TimeslotId]
-
-ConstraintSetDict = dict[IdType, set[str]]
-"""Dictionary containing the constraint strings per object id."""
-
-# different values to store for the different solving stages
-Var: TypeAlias = LpVariable
-PartialSolved = int | None
-Solved = int
-
-# nested dictionaries containing either the LP variables (`VarDict`)
-# or the values assigned to them by the solver (`PartialSolvedVarDict`, `SolvedVarDict`)
-GenericVarDict = dict[IdType, dict[IdType2, T]]
-VarDict = GenericVarDict[IdType, IdType2, Var]
-PartialSolvedVarDict = GenericVarDict[IdType, IdType2, PartialSolved]
-SolvedVarDict = GenericVarDict[IdType, IdType2, Solved]
+Block = pd.Index[TimeslotId]
 
 
-class ExportTuple(NamedTuple, Generic[T]):
+class ExportTuple(NamedTuple):
     """Named tuple containing the LP variables resp. their values."""
 
-    room: GenericVarDict[AkId, RoomId, T]
-    time: GenericVarDict[AkId, TimeslotId, T]
-    person: GenericVarDict[AkId, PersonId, T]
+    room: xr.DataArray
+    time: xr.DataArray
+    person: xr.DataArray
+
+
+class SolverKwargs(TypedDict, total=False):
+    """Key word arguments to initialize the linopy solver."""
+
+    # TODO check kwargs names
+    timeLimit: NotRequired[float]  # noqa: N815
+    gapRel: NotRequired[float]  # noqa: N815
+    gapAbs: NotRequired[float]  # noqa: N815
+    threads: NotRequired[int]
+    warmstart_fn: NotRequired[str | Path | None]

--- a/src/akplan/types.py
+++ b/src/akplan/types.py
@@ -17,7 +17,7 @@ PersonId = Id
 AkId = Id
 TimeslotId = Id
 BlockId = Id
-Block = pd.Index[TimeslotId]
+Block = pd.Index
 
 
 class ExportTuple(NamedTuple):

--- a/src/akplan/types.py
+++ b/src/akplan/types.py
@@ -1,0 +1,40 @@
+"""Type definitions."""
+
+from typing import Generic, NamedTuple, TypeAlias, TypeVar
+
+from pulp import LpVariable
+
+Id = int
+T = TypeVar("T")
+IdType = TypeVar("IdType", bound=Id)
+IdType2 = TypeVar("IdType2", bound=Id)
+
+RoomId = Id
+PersonId = Id
+AkId = Id
+TimeslotId = Id
+BlockId = Id
+Block = list[TimeslotId]
+
+ConstraintSetDict = dict[IdType, set[str]]
+"""Dictionary containing the constraint strings per object id."""
+
+# different values to store for the different solving stages
+Var: TypeAlias = LpVariable
+PartialSolved = int | None
+Solved = int
+
+# nested dictionaries containing either the LP variables (`VarDict`)
+# or the values assigned to them by the solver (`PartialSolvedVarDict`, `SolvedVarDict`)
+GenericVarDict = dict[IdType, dict[IdType2, T]]
+VarDict = GenericVarDict[IdType, IdType2, Var]
+PartialSolvedVarDict = GenericVarDict[IdType, IdType2, PartialSolved]
+SolvedVarDict = GenericVarDict[IdType, IdType2, Solved]
+
+
+class ExportTuple(NamedTuple, Generic[T]):
+    """Named tuple containing the LP variables resp. their values."""
+
+    room: GenericVarDict[AkId, RoomId, T]
+    time: GenericVarDict[AkId, TimeslotId, T]
+    person: GenericVarDict[AkId, PersonId, T]

--- a/src/akplan/types.py
+++ b/src/akplan/types.py
@@ -19,6 +19,13 @@ TimeslotId = Id
 BlockId = Id
 Block = pd.Index
 
+ScheduleAtomComparisonTuple = tuple[
+    AkId,
+    RoomId | None,
+    tuple[TimeslotId, ...],
+    tuple[PersonId, ...],
+]
+
 
 class ExportTuple(NamedTuple):
     """Named tuple containing the LP variables resp. their values."""

--- a/src/akplan/types.py
+++ b/src/akplan/types.py
@@ -1,7 +1,7 @@
 """Type definitions."""
 
 from pathlib import Path
-from typing import NamedTuple, TypedDict, TypeVar
+from typing import Literal, NamedTuple, TypedDict, TypeVar
 
 import pandas as pd
 import xarray as xr
@@ -28,12 +28,28 @@ class ExportTuple(NamedTuple):
     person: xr.DataArray
 
 
-class SolverKwargs(TypedDict, total=False):
-    """Key word arguments to initialize the linopy solver."""
+SupportedSolver = Literal["gurobi", "highs"]
 
-    # TODO check kwargs names
-    timeLimit: NotRequired[float]  # noqa: N815
-    gapRel: NotRequired[float]  # noqa: N815
-    gapAbs: NotRequired[float]  # noqa: N815
-    threads: NotRequired[int]
+
+class SolverKwargs(TypedDict, total=False):
+    """Key word arguments to initialize an unsupported linopy solver."""
+
     warmstart_fn: NotRequired[str | Path | None]
+
+
+class GurobiSolverKwargs(SolverKwargs):
+    """Key word arguments to initialize the Gurobi linopy solver."""
+
+    TimeLimit: NotRequired[float]  # noqa: N815
+    MIPGap: NotRequired[float]  # noqa: N815
+    MIPGapAbs: NotRequired[float]  # noqa: N815
+    Threads: NotRequired[int]  # noqa: N815
+
+
+class HighsSolverKwargs(SolverKwargs):
+    """Key word arguments to initialize the HiGHS linopy solver."""
+
+    time_limit: NotRequired[float]
+    mip_rel_gap: NotRequired[float]
+    mip_abs_gap: NotRequired[float]
+    threads: NotRequired[int]

--- a/src/akplan/types.py
+++ b/src/akplan/types.py
@@ -35,6 +35,7 @@ class SolverKwargs(TypedDict, total=False):
     """Key word arguments to initialize an unsupported linopy solver."""
 
     warmstart_fn: NotRequired[str | Path | None]
+    io_api: Literal["direct", "lp", "mps"]
 
 
 class GurobiSolverKwargs(SolverKwargs):

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -324,11 +324,11 @@ def process_room_cap(room_capacity: int, num_participants: int) -> int:
 class ProblemIds:
     """Dataclass containing the id collections from a problem."""
 
-    ak: pd.Index[types.AkId]
-    room: pd.Index[types.RoomId]
-    timeslot: pd.Index[types.TimeslotId]
-    person: pd.Index[types.PersonId]
-    block: pd.Index[types.BlockId]
+    ak: pd.Index
+    room: pd.Index
+    timeslot: pd.Index
+    person: pd.Index
+    block: pd.Index
     block_dict: dict[types.BlockId, types.Block]
     conflict_pairs: set[tuple[types.AkId, types.AkId]]
 
@@ -460,7 +460,7 @@ class ProblemProperties:
                 num_required_per_ak == 0, drop=True
             ).coords["ak"]:
                 print(
-                    f"Warning: AK {get_ak_name(input_data, ak_id)} with id {ak_id} "
+                    f"Warning: AK {get_ak_name(input_data, ak_id)} with id {ak_id.item()} "
                     "has no required persons. Who owns this?"
                 )
 

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -159,14 +159,7 @@ class ScheduleAtom:
     participant_ids: np.ndarray
 
     @property
-    def _comparison_tuple(
-        self,
-    ) -> tuple[
-        types.AkId,
-        types.RoomId | None,
-        tuple[types.TimeslotId, ...],
-        tuple[types.PersonId, ...],
-    ]:
+    def _comparison_tuple(self) -> types.ScheduleAtomComparisonTuple:
         return (
             self.ak_id,
             self.room_id,

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -190,10 +190,18 @@ class ScheduleAtom:
         """Calculate hash by hashing the `_comparison_tuple`."""
         return hash(self._comparison_tuple)
 
-    def strip_participants(self) -> ScheduleAtom:
-        """Clone this object and remove all participants from the copy."""
+    def stripped_copy(
+        self,
+        strip_room: bool = False,
+        strip_timeslots: bool = False,
+        strip_participants: bool = False,
+    ) -> ScheduleAtom:
+        """Clone this object and strip selectef fields from the copy."""
         return ScheduleAtom(
-            self.ak_id, self.room_id, self.timeslot_ids.copy(), np.array([])
+            self.ak_id,
+            None if strip_room else self.room_id,
+            np.array([]) if strip_timeslots else self.timeslot_ids.copy(),
+            np.array([]) if strip_participants else self.participant_ids.copy(),
         )
 
 

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -10,10 +10,7 @@ from typing import Any, Type
 from dacite import from_dict
 from pulp import LpBinary, LpVariable
 
-VarDict = dict[int, dict[int, LpVariable]]
-PartialSolvedVarDict = dict[int, dict[int, int | None]]
-SolvedVarDict = dict[int, dict[int, int]]
-ConstraintSetDict = dict[int, set[str]]
+from . import types
 
 
 @dataclass(frozen=True)
@@ -35,7 +32,7 @@ class AKData:
             human readable name or a description. Not used for the optimization.
     """
 
-    id: int
+    id: types.AkId
     duration: int
     properties: dict[str, Any]
     room_constraints: list[str]
@@ -57,7 +54,7 @@ class PreferenceData:
             weakly interested (1), strongly interested (2) or required (-1).
     """
 
-    ak_id: int
+    ak_id: types.AkId
     required: bool
     preference_score: int
 
@@ -81,7 +78,7 @@ class ParticipantData:
             e.g. a human readable name. Not used for the optimization.
     """
 
-    id: int
+    id: types.PersonId
     preferences: list[PreferenceData]
     room_constraints: list[str]
     time_constraints: list[str]
@@ -107,7 +104,7 @@ class RoomData:
             e.g. a human readable name. Not used for the optimization.
     """
 
-    id: int
+    id: types.RoomId
     capacity: int
     fulfilled_room_constraints: list[str]
     time_constraints: list[str]
@@ -129,7 +126,7 @@ class TimeSlotData:
             e.g. a human readable start time and date. Not used for the optimization.
     """
 
-    id: int
+    id: types.TimeslotId
     fulfilled_time_constraints: list[str]
     info: dict[str, Any]
 
@@ -146,10 +143,10 @@ class ScheduleAtom:
         participant_ids (list of int): The list of participants that are meant to go to this AK.
     """
 
-    ak_id: int
-    room_id: int | None
-    timeslot_ids: list[int]
-    participant_ids: list[int]
+    ak_id: types.AkId
+    room_id: types.RoomId | None
+    timeslot_ids: list[types.TimeslotId]
+    participant_ids: list[types.PersonId]
 
 
 @dataclass(frozen=False)
@@ -256,7 +253,7 @@ class SchedulingInput:
         return return_dict
 
 
-def get_ak_name(input_data: SchedulingInput, ak_id: int) -> str:
+def get_ak_name(input_data: SchedulingInput, ak_id: types.AkId) -> str:
     """Get name string for an AK."""
     ak_names = [
         ak.info["name"]
@@ -323,24 +320,27 @@ def process_room_cap(room_capacity: int, num_participants: int) -> int:
 class ProblemIds:
     """Dataclass containing the id collections from a problem."""
 
-    ak: set[int]
-    room: set[int]
-    timeslot: set[int]
-    person: set[int]
-    block_dict: dict[int, list[int]]
-    sorted_timeslot: list[int]
+    ak: set[types.AkId]
+    room: set[types.RoomId]
+    timeslot: set[types.TimeslotId]
+    person: set[types.PersonId]
+    block_dict: dict[types.BlockId, types.Block]
+    sorted_timeslot: list[types.TimeslotId]
+    conflict_pairs: set[tuple[types.AkId, types.AkId]]
 
     @staticmethod
     def get_ids(
         input_data: SchedulingInput,
-    ) -> tuple[set[int], set[int], set[int], set[int]]:
+    ) -> tuple[
+        set[types.AkId], set[types.PersonId], set[types.RoomId], set[types.TimeslotId]
+    ]:
         """Create id sets from scheduling input."""
 
         def _retrieve_ids(
             input_iterable: Iterable[
                 AKData | ParticipantData | RoomData | TimeSlotData
             ],
-        ) -> set[int]:
+        ) -> set[types.Id]:
             return {obj.id for obj in input_iterable}
 
         ak_ids = _retrieve_ids(input_data.aks)
@@ -363,6 +363,21 @@ class ProblemIds:
             for block_idx, block in enumerate(input_data.timeslot_blocks)
         }
 
+        conflict_pairs: set[tuple[types.AkId, types.AkId]] = set()
+        for ak in input_data.aks:
+            conflicting_aks: list[types.AkId] = ak.properties.get("conflicts", [])
+            depending_aks: list[types.AkId] = ak.properties.get("dependencies", [])
+            conflict_pairs.update(
+                [
+                    (
+                        (ak.id, other_ak_id)
+                        if ak.id < other_ak_id
+                        else (other_ak_id, ak.id)
+                    )
+                    for other_ak_id in conflicting_aks + depending_aks
+                ]
+            )
+
         return cls(
             ak=ak_ids,
             room=room_ids,
@@ -370,6 +385,7 @@ class ProblemIds:
             person=person_ids,
             block_dict=block_dict,
             sorted_timeslot=sorted_timeslot_ids,
+            conflict_pairs=conflict_pairs,
         )
 
 
@@ -377,18 +393,18 @@ class ProblemIds:
 class ProblemProperties:
     """Dataclass containing derived properties from a problem."""
 
-    room_capacities: dict[int, int]
-    ak_durations: dict[int, int]
-    weighted_preferences: dict[int, dict[int, float]]
-    required_persons: dict[int, set[int]]
-    ak_num_interested: dict[int, int]
-    participant_time_constraints: ConstraintSetDict
-    participant_room_constraints: ConstraintSetDict
-    ak_time_constraints: ConstraintSetDict
-    ak_room_constraints: ConstraintSetDict
-    room_time_constraints: ConstraintSetDict
-    fulfilled_time_constraints: ConstraintSetDict
-    fulfilled_room_constraints: ConstraintSetDict
+    room_capacities: dict[types.RoomId, int]
+    ak_durations: dict[types.AkId, int]
+    weighted_preferences: dict[types.PersonId, dict[types.AkId, float]]
+    required_persons: dict[types.AkId, set[types.PersonId]]
+    ak_num_interested: dict[types.AkId, int]
+    participant_time_constraints: types.ConstraintSetDict[types.PersonId]
+    participant_room_constraints: types.ConstraintSetDict[types.PersonId]
+    ak_time_constraints: types.ConstraintSetDict[types.AkId]
+    ak_room_constraints: types.ConstraintSetDict[types.AkId]
+    room_time_constraints: types.ConstraintSetDict[types.RoomId]
+    fulfilled_time_constraints: types.ConstraintSetDict[types.TimeslotId]
+    fulfilled_room_constraints: types.ConstraintSetDict[types.RoomId]
 
     @classmethod
     def init_from_problem(
@@ -491,42 +507,46 @@ class ProblemProperties:
 class LPVarDicts:
     """Dataclass containing the decision variable dicts for the LP."""
 
-    room: VarDict
-    time: VarDict
-    block: VarDict
-    person: VarDict
-    person_time: VarDict
+    room: types.VarDict[types.AkId, types.RoomId]
+    time: types.VarDict[types.AkId, types.TimeslotId]
+    block: types.VarDict[types.AkId, types.BlockId]
+    person: types.VarDict[types.AkId, types.PersonId]
+    person_time: types.VarDict[types.PersonId, types.TimeslotId]
 
-    def to_export_dict(self) -> dict[str, VarDict]:
+    def to_export_tuple(self) -> types.ExportTuple[types.Var]:
         """We only export the variables for room, time, and persons."""
-        return {"Room": self.room, "Time": self.time, "Part": self.person}
+        return types.ExportTuple(room=self.room, time=self.time, person=self.person)
 
     @classmethod
     def init_from_ids(
         cls: Type["LPVarDicts"],
-        ak_ids: Collection[int],
-        room_ids: Collection[int],
-        timeslot_ids: Collection[int],
-        block_ids: Collection[int],
-        person_ids: Collection[int],
+        ak_ids: Collection[types.AkId],
+        room_ids: Collection[types.RoomId],
+        timeslot_ids: Collection[types.TimeslotId],
+        block_ids: Collection[types.BlockId],
+        person_ids: Collection[types.PersonId],
     ) -> "LPVarDicts":
         """Initialize decision variables from the problem ids."""
-        room_var: VarDict = LpVariable.dicts("Room", (ak_ids, room_ids), cat=LpBinary)
-        time_var: VarDict = LpVariable.dicts(
+        room_var: types.VarDict[types.AkId, types.RoomId] = LpVariable.dicts(
+            "Room", (ak_ids, room_ids), cat=LpBinary
+        )
+        time_var: types.VarDict[types.AkId, types.TimeslotId] = LpVariable.dicts(
             "Time",
             (ak_ids, timeslot_ids),
             cat=LpBinary,
         )
-        block_var: VarDict = LpVariable.dicts(
+        block_var: types.VarDict[types.AkId, types.BlockId] = LpVariable.dicts(
             "Block", (ak_ids, block_ids), cat=LpBinary
         )
-        person_var: VarDict = LpVariable.dicts(
+        person_var: types.VarDict[types.AkId, types.PersonId] = LpVariable.dicts(
             "Part", (ak_ids, person_ids), cat=LpBinary
         )
-        person_time_var: VarDict = LpVariable.dicts(
-            "Working",
-            (person_ids, timeslot_ids),
-            cat=LpBinary,
+        person_time_var: types.VarDict[types.PersonId, types.TimeslotId] = (
+            LpVariable.dicts(
+                "Working",
+                (person_ids, timeslot_ids),
+                cat=LpBinary,
+            )
         )
         return cls(
             room=room_var,
@@ -535,3 +555,7 @@ class LPVarDicts:
             person=person_var,
             person_time=person_time_var,
         )
+
+
+def _construct_constraint_name(name: str, *args: Any) -> str:
+    return name + "_" + "_".join(map(str, args))

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -160,11 +160,13 @@ class ScheduleAtom:
 
     @property
     def _comparison_tuple(self) -> types.ScheduleAtomComparisonTuple:
+        self.timeslot_ids.sort()
+        self.participant_ids.sort()
         return (
             self.ak_id,
             self.room_id,
-            tuple(sorted(self.timeslot_ids)),
-            tuple(sorted(self.participant_ids)),
+            tuple(self.timeslot_ids),
+            tuple(self.participant_ids),
         )
 
     def __lt__(self, other: object) -> bool:
@@ -190,6 +192,9 @@ class ScheduleAtom:
         strip_participants: bool = False,
     ) -> ScheduleAtom:
         """Clone this object and strip selectef fields from the copy."""
+        # sort before copy to avoid double effort
+        self.timeslot_ids.sort()
+        self.participant_ids.sort()
         return ScheduleAtom(
             self.ak_id,
             None if strip_room else self.room_id,

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from itertools import chain
@@ -14,6 +15,8 @@ import xarray as xr
 from dacite import from_dict
 
 from . import types
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, order=True)
@@ -460,9 +463,10 @@ class ProblemProperties:
             for ak_id in num_required_per_ak.where(
                 num_required_per_ak == 0, drop=True
             ).coords["ak"]:
-                print(
-                    f"Warning: AK {get_ak_name(input_data, ak_id)} with id {ak_id.item()} "
-                    "has no required persons. Who owns this?"
+                logger.warning(
+                    "AK %s with id %d has no required persons. Who owns this?",
+                    get_ak_name(input_data, ak_id),
+                    ak_id.item(),
                 )
 
         ak_num_interested = num_required_per_ak + (preferences != 0).sum("person")
@@ -614,9 +618,10 @@ class SolverConfig:
             return gurobi_solver_kwargs
         else:
             if self._has_non_none_attr:
-                print(
-                    f"Warning: exporting CLI args to solver '{solver_name}' is not supported. "
-                    "The solver is run with its default parameters."
+                logger.warning(
+                    "Exporting CLI args to solver '%s' is not supported. "
+                    "The solver is run with its default parameters.",
+                    solver_name,
                 )
             solver_kwargs: types.SolverKwargs = {}
             if self.warmstart_fn is not None:

--- a/src/akplan/util.py
+++ b/src/akplan/util.py
@@ -491,8 +491,7 @@ class ProblemProperties:
             coords=[ids.ak],
         )
 
-        # dict of real participants only (without dummy participants)
-        # with numerical preferences
+        # xarray of participants with numerical preferences
         preferences = xr.DataArray(0.0, coords=[ids.ak, ids.person])
         required_persons = xr.DataArray(False, coords=[ids.ak, ids.person])
         for person in input_data.participants:

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -5,13 +5,13 @@ import multiprocessing
 from collections import defaultdict
 from itertools import product
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeVar, cast
 
 import linopy
 import linopy.solvers
 import numpy as np
 import pytest
-from pytest.structure import ParameterSet
+from _pytest.mark import ParameterSet
 
 from akplan import types
 from akplan.solve import process_solved_lp, solve_scheduling
@@ -87,14 +87,15 @@ scheduled_aks_params: list[ParameterSet] = [
     )
     for param_pair in product(mus, available_solvers)
 ]
+scheduled_aks_param_ids: list[str] = []
+for param in scheduled_aks_params:
+    mu, solver_name = cast(tuple[float, str], param.values[0])
+    scheduled_aks_param_ids.append(f"mu={mu}-{solver_name}")
 
 
 @pytest.fixture(
     scope="module",
-    ids=[
-        f"mu={param.values[0][0]}-{param.values[0][1]}"
-        for param in scheduled_aks_params
-    ],
+    ids=scheduled_aks_param_ids,
     params=scheduled_aks_params,
 )
 def solved_lp_fixture(

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -1,7 +1,6 @@
 """Unit tests to check feasibility of the constructed schedules."""
 
 import json
-import multiprocessing
 from collections import defaultdict
 from itertools import product
 from pathlib import Path
@@ -23,6 +22,7 @@ from akplan.util import (
     SchedulingInput,
     SolverConfig,
     TimeSlotData,
+    default_num_threads,
 )
 
 T = TypeVar("T")
@@ -105,7 +105,7 @@ def solved_lp_fixture(
     """Solve an ILP."""
     mu, solver_name = request.param
     solver_config = SolverConfig(
-        threads=max(1, multiprocessing.cpu_count() - 1),
+        threads=default_num_threads(),
         time_limit=60,
     )
     scheduling_input.config.mu = mu

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -21,6 +21,7 @@ from akplan.util import (
     RoomData,
     ScheduleAtom,
     SchedulingInput,
+    SolverConfig,
     TimeSlotData,
 )
 
@@ -103,16 +104,16 @@ def solved_lp_fixture(
 ) -> tuple[linopy.Model, types.ExportTuple, SchedulingInput]:
     """Solve an ILP."""
     mu, solver_name = request.param
-    solver_kwargs: types.SolverKwargs = {}
-    if solver_name not in ["glpk"]:
-        solver_kwargs["threads"] = max(1, multiprocessing.cpu_count() - 1)
-    solver_kwargs["timeLimit"] = 60
+    solver_config = SolverConfig(
+        threads=max(1, multiprocessing.cpu_count() - 1),
+        time_limit=60,
+    )
     scheduling_input.config.mu = mu
 
     solved_lp_problem, solution = solve_scheduling(
         scheduling_input,
+        solver_config=solver_config,
         solver_name=solver_name,
-        **solver_kwargs,
     )
     return (solved_lp_problem, solution, scheduling_input)
 

--- a/tests/test_schedule_feasibility.py
+++ b/tests/test_schedule_feasibility.py
@@ -110,12 +110,14 @@ def solved_lp_fixture(
     )
     scheduling_input.config.mu = mu
 
-    solved_lp_problem, solution = solve_scheduling(
+    solution_tuple = solve_scheduling(
         scheduling_input,
         solver_config=solver_config,
         solver_name=solver_name,
     )
-    return (solved_lp_problem, solution, scheduling_input)
+    assert solution_tuple is not None, "Model is infeasible!"
+
+    return (*solution_tuple, scheduling_input)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR bundles multiple changes. The main change is a replacement of the library we use to interface to the solvers. On large instances, the LP construction time of the current choice (PuLP) was unsustainably long, measuring 10-40 minutes. Attempts to parallelize the construction were not fruitful.
Hence, this PR rewrites the main business logic of this tool to use [linopy](https://github.com/PyPSA/linopy) instead, which is quite a bit faster on large instances (and should also require less memory).

Further changes:
1. The configuration is moved to a `pyproject.toml` file
2. New minimum python version: 3.11
4. Uses python `logging` instead of print statements for log messages
5. Tweaks to the CLI interface.
6. We now use dynamic generation of the versioning
7. Tweaks to the noxfile. In particular, all nox sessions now use the default pip backend.
8. Improved typing, new module `types.py`, typed the tests
9. We now default to direct invocation of the solver backend if possible (i.e. the write/read of the LP to a file on disk is now optional)
10. We now default the number of threads to `# available CPUs - 1`
11. We so far have not declared any license for this repo. I think choosing a permissive license would be a good idea. I would propose MIT

---
### ToDos

* [x] Cleanup commit history a bit
* [x] Update wiki with simpler form of AKBlockAssign