### PR TITLE
Feature: Support keyboard interrupts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ format = ["ruff"]
 lint = ["ruff"]
 test = ["highspy", "gurobipy", "pytest", "pytest-timeout"]
 coverage = ["coverage"]
-typing = ["pytest", "mypy"]
+typing = ["highspy", "pytest", "mypy"]
 
 [project.urls]
 Source = "https://github.com/Die-KoMa/ak-plan-optimierung"
@@ -61,6 +61,10 @@ strict = true
 install_types = true
 non_interactive = true
 exclude_gitignore = true
+
+[[tool.mypy.overrides]]
+module = ["highspy.*"]
+follow_untyped_imports = true
 
 [tool.ruff]
 extend-exclude = ["*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,15 @@ dependencies = [
     "pandas",
     "xarray",
     "linopy",
+    "highspy>=1.8.0",
 ]
 
 [project.optional-dependencies]
 format = ["ruff"]
 lint = ["ruff"]
-test = ["highspy", "gurobipy", "pytest", "pytest-timeout"]
+test = ["gurobipy", "pytest", "pytest-timeout"]
 coverage = ["coverage"]
-typing = ["highspy", "pytest", "mypy"]
+typing = ["pytest", "mypy"]
 
 [project.urls]
 Source = "https://github.com/Die-KoMa/ak-plan-optimierung"

--- a/src/akplan/__init__.py
+++ b/src/akplan/__init__.py
@@ -8,4 +8,6 @@ __version__ = version("akplan")
 # by user interrupt not as an 'ok' solver state, so the solution values
 # are discarded. We patch this by trying to read a solution after a
 # user interrupt.
+# Note: We also patch linopy's Highs solver class to make the Highs
+# solver listen to keyboard interrupts.
 import akplan.monkeypatch_linopy  # noqa: F401

--- a/src/akplan/__init__.py
+++ b/src/akplan/__init__.py
@@ -1,1 +1,11 @@
 """Conference scheduling using MILPs."""
+
+from importlib.metadata import version
+
+__version__ = version("akplan")
+
+# Note: The linopy solver base class handles a solver termination
+# by user interrupt not as an 'ok' solver state, so the solution values
+# are discarded. We patch this by trying to read a solution after a
+# user interrupt.
+import akplan.monkeypatch_linopy  # noqa: F401

--- a/src/akplan/monkeypatch_linopy.py
+++ b/src/akplan/monkeypatch_linopy.py
@@ -1,0 +1,74 @@
+"""Monkey patches to the linopy library."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from functools import partialmethod, update_wrapper
+from typing import TYPE_CHECKING
+
+from linopy.constants import Solution, SolverStatus, TerminationCondition
+from linopy.solvers import Solver
+
+if TYPE_CHECKING:
+    from linopy.constants import Status
+
+
+logger = logging.getLogger(__name__)
+
+
+def monkey_patch(
+    cls: type[Solver],
+    pass_unpatched_method: bool = False,
+) -> Callable:  # type: ignore[type-arg]
+    """Decorate to monkey patch solver methods.
+
+    Adapted from `linopy.monkey_patch_xarray`.
+
+    Args:
+        cls (type[Solver]): The linopy solver class to patch.
+        pass_unpatched_method (bool): Whether to pass the original method
+            as an kwarg to the patched method.
+
+    Returns:
+        Callable: A decorator which expects the input func to have the name
+        of the method to replace. Expects the patch func to have the same
+        signature as the method to patch; if `pass_unpatched_method` is True,
+        we further assume the keyword argument `unpatched_method`.
+    """
+
+    def deco(func: Callable) -> Callable:  # type: ignore[type-arg]
+        func_name = func.__name__
+        wrapped = getattr(cls, func_name)
+        update_wrapper(func, wrapped)
+        if pass_unpatched_method:
+            func = partialmethod(func, unpatched_method=wrapped)  # type: ignore
+        setattr(cls, func_name, func)
+        return func
+
+    return deco
+
+
+@monkey_patch(Solver, pass_unpatched_method=True)  # type: ignore[type-abstract]
+def safe_get_solution(
+    solver: Solver,
+    status: Status,
+    func: Callable[[], Solution],
+    unpatched_method: Callable[[Solver, Status, Callable[[], Solution]], Solution],
+) -> Solution:
+    """Patch `safe_get_solution` to read solution after user interrupt."""
+    if (
+        not status.is_ok
+        and status.termination_condition == TerminationCondition.user_interrupt
+    ):
+        try:
+            logger.warning("Termination status user aborted. Trying to parse solution.")
+            sol = func()
+            status.status = SolverStatus.ok
+            logger.warning("Solution parsed successfully.")
+            return sol
+        except Exception as e:
+            logger.error(f"Failed to parse solution: {e}")
+            return Solution()
+
+    return unpatched_method(solver, status, func)

--- a/src/akplan/monkeypatch_linopy.py
+++ b/src/akplan/monkeypatch_linopy.py
@@ -1,17 +1,26 @@
-"""Monkey patches to the linopy library."""
+"""Monkey patches to the linopy library.
+
+This patches the linopy library in two ways:
+1. After a user interrupt, we attempt to read a solution
+   and if we suceed, we consider the solution status to be ok.
+2. We make the HiGHS solver listen to keyboard interrupts.
+"""
 
 from __future__ import annotations
 
 import logging
 from collections.abc import Callable
 from functools import partialmethod, update_wrapper
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
 
 from linopy.constants import Solution, SolverStatus, TerminationCondition
-from linopy.solvers import Solver
+from linopy.solvers import Highs, Solver
 
 if TYPE_CHECKING:
-    from linopy.constants import Status
+    import highspy
+    from linopy.constants import Result, Status
+    from linopy.model import Model
 
 
 logger = logging.getLogger(__name__)
@@ -68,7 +77,57 @@ def safe_get_solution(
             logger.warning("Solution parsed successfully.")
             return sol
         except Exception as e:
-            logger.error(f"Failed to parse solution: {e}")
+            logger.error("Failed to parse solution: %s", e)
             return Solution()
 
     return unpatched_method(solver, status, func)
+
+
+class _SolverFunc(Protocol):
+    """Protocol to type hint the Highs._solve method."""
+
+    def __call__(
+        self,
+        solver: Highs,
+        h: highspy.Highs,
+        solution_fn: Path | None = None,
+        log_fn: Path | None = None,
+        warmstart_fn: Path | None = None,
+        basis_fn: Path | None = None,
+        model: Model | None = None,
+        io_api: str | None = None,
+        sense: str | None = None,
+    ) -> Result: ...
+
+
+@monkey_patch(Highs, pass_unpatched_method=True)
+def _solve(
+    solver: Highs,
+    h: highspy.Highs,
+    solution_fn: Path | None = None,
+    log_fn: Path | None = None,
+    warmstart_fn: Path | None = None,
+    basis_fn: Path | None = None,
+    model: Model | None = None,
+    io_api: str | None = None,
+    sense: str | None = None,
+    *,
+    unpatched_method: _SolverFunc,
+) -> Result:
+    """Patch `_solve` to make HiGHS listen for keyboard interrupts."""
+    # patch to use the highspy Model's solve function as the entry point
+    # `run` falls back to the C version, which skips the python code
+    # which allows to listen for keyboard interrupts.
+    h.run = h.solve  # type: ignore[method-assign]
+    h.HandleKeyboardInterrupt = True
+    return unpatched_method(
+        solver,
+        h,
+        solution_fn=solution_fn,
+        log_fn=log_fn,
+        warmstart_fn=warmstart_fn,
+        basis_fn=basis_fn,
+        model=model,
+        io_api=io_api,
+        sense=sense,
+    )


### PR DESCRIPTION
A common use case for us is to start the solver and interrupt manually, see #11

The rewrite to linopy makes this easier. However, I stumbled onto two issues that this PR addresses:

1. If a solver returns after a keyboard interrupt, the termination status is `user_interrupt`. This however is a status that is not considered `ok`. And the solution values are only read for `ok` status (although they are available). This PR monkey patches linopy's Solver base class to address this.
2. Further, the `highspy` backend by default does _not_ listen to keyboard interrupts as this requires an additional thread to be spawned. We also patch linopy to enable the Highs models to listen to interrupts.

Closes #11