### PR TITLE
Add Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779102034,
+        "narHash": "sha256-uTBbAAmkcLK3Fd3RjXG/VX1jkiY0gdh+oqWyB+BjyhI=",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.11112.687f05a9184c/nixexprs.tar.xz?lastModified=1779102034&rev=687f05a9184cad4eaf905c48b63649e3a86f5433"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,132 @@
+{
+  inputs = {
+    nixpkgs.url = "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }@inputs:
+    let
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs [ "x86_64-linux" ] (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+            }
+          )
+        );
+      python' = p: p.python3;
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          python = python' pkgs;
+        in
+        rec {
+          ak-plan-optimierung =
+            let
+              src = pkgs.fetchFromGitHub {
+                owner = "die-koma";
+                repo = "ak-plan-optimierung";
+                rev = "e5453e225369820bab3e2d294f0f226bffcabc58";
+                hash = "sha256-a2thR6ntXU5CAuCbg37BIHj8QhpHjkb/0js9w2sxKPQ=";
+              };
+            in
+            python.pkgs.buildPythonApplication {
+              name = "ak-plan-optimierung";
+              version = "0.0";
+              pyproject = true;
+              build-system = [ python.pkgs.setuptools ];
+              nativeBuildInputs = [ python.pkgs.setuptools-scm ];
+
+              inherit src;
+
+              dependencies = pkgs.lib.attrValues {
+                inherit (python.pkgs)
+                  dacite
+                  tqdm
+                  numpy
+                  pandas
+                  xarray
+                  gurobipy
+                  highspy
+                  pytest
+                  pytest-timeout
+                  ;
+                inherit (self.packages.${pkgs.stdenv.hostPlatform.system})
+                  linopy
+                  ;
+              };
+
+              meta = {
+                license = pkgs.lib.licenses.mit;
+                mainProgram = "akplan-solve";
+              };
+            };
+
+          linopy = python.pkgs.buildPythonPackage rec {
+            pname = "linopy";
+            version = "0.5.8";
+            pyproject = true;
+
+            src = pkgs.fetchPypi {
+              inherit pname version;
+              hash = "sha256-pN1mEFRKJ50KL3YguQChi1FzBhzZAtXCBiHElXbFwnE=";
+            };
+
+            build-system = [ python.pkgs.setuptools ];
+            nativeBuildInputs = [
+              python.pkgs.setuptools-scm
+              pkgs.which
+            ];
+
+            dependencies = pkgs.lib.attrValues {
+              inherit (python.pkgs)
+                numpy
+                scipy
+                bottleneck
+                toolz
+                numexpr
+                xarray
+                dask
+                polars
+                tqdm
+                deprecation
+                packaging
+                gurobipy
+                requests
+                google-cloud-storage
+                ;
+            };
+
+            pythonImportsCheck = [ "linopy" ];
+          };
+
+          default = ak-plan-optimierung;
+        }
+      );
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = pkgs.lib.attrValues {
+            inherit ((python' pkgs).pkgs)
+              black
+              ruff
+              pytest
+              mypy
+              coverage
+              ;
+            inherit (pkgs) gurobi;
+          };
+          inputsFrom = [ self.packages.${pkgs.stdenv.hostPlatform.system}.ak-plan-optimierung ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
Add a Nix flake that sets up all the dependencies, including Gurobi.

I've pinned linopy 0.5.8, since the 0.6 versions produce incompatible array shapes (it looks like one of them is now transposed).